### PR TITLE
Add kubernetesDeployApp pipeline function

### DIFF
--- a/vars/kubernetesDeployApp.groovy
+++ b/vars/kubernetesDeployApp.groovy
@@ -1,0 +1,29 @@
+/**
+ * Make the Kubernetes namespace for an app, and deploy it with the given
+ * version.
+*/
+
+import groovy.json.JsonOutput
+
+def call(String app, String version) {
+    def namespace = "app-$app"
+    def json = JsonOutput.toJson([
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: [name: namespace]
+    ])
+
+    File namespaceFile = File.createTempFile('namespace', '.tmp')
+    namespaceFile.write json
+    namespaceFile.deleteOnExit()
+
+    withKubeConfig([credentialsId: 'kubernetes-deploy-token',
+                    serverUrl: 'https://hozer-75.ocf.berkeley.edu:6443'
+                    ]) {
+        sh "kubectl apply -f $namespaceFile.absolutePath"
+        sh """
+            kubernetes-deploy $namespace k8s --template-dir kubernetes \
+                --bindings=version=${version}
+        """
+    }
+}


### PR DESCRIPTION
This adds the pipeline function for deploying to Kubernetes. Some further explanation of what this does:

* This is a slight departure from the current way we do things with Marathon. Currently, service definitions are defined in a "services" repo. Instead, we'll now define services in a `kubernetes` directory in each service's repo.
* We use the [`kubernetes-deploy`](https://github.com/Shopify/kubernetes-deploy) script to on all the yaml files in the `kubernetes` directory. This will monitor the deploy and make sure that the changes are actually made (`kubectl apply` won't give us this information)
* `kubernetes-deploy` wants each app to have its own Kubernetes namespace, so we create the namespace before running this. We construct the JSON, put it in a temp file, and pass it as an argument to `kubectl apply`.
* The Kubernetes service definition is actually an ERB template, which gets filled in by `kubernetes-deploy`. We substitute in the `version` variable, which controls upgrading Docker container versions.