### PR TITLE
Use chronic for ircNotification

### DIFF
--- a/vars/ircNotification.groovy
+++ b/vars/ircNotification.groovy
@@ -19,6 +19,6 @@ def call(String channel = '#rebuild-spam',
         echo "JOIN ${channel}"
         echo "PRIVMSG ${channel} :${message}"
         echo QUIT
-        ) | openssl s_client -connect ${server}
+        ) | chronic openssl s_client -connect ${server}
     """
 }


### PR DESCRIPTION
The IRC notification clutters the bottom of build output, where we usually want to look to see why a build fails. This commit uses `chronic` to silence the IRC output (unless it fails, which it pretty much never does).