### PR TITLE
Allow not having a makefile

### DIFF
--- a/vars/servicePipeline.groovy
+++ b/vars/servicePipeline.groovy
@@ -64,7 +64,7 @@ def call(Map pipelineParams) {
 
                     stage('cook-image') {
                         steps {
-                            sh 'make cook-image'
+                            sh 'make -q cook-image || if [ "$?" -ne "2" ]; then make cook-image; fi'
                         }
                     }
                 }
@@ -82,7 +82,7 @@ def call(Map pipelineParams) {
                     label 'deploy'
                 }
                 steps {
-                    sh 'make push-image'
+                    sh 'make -q push-image || if [ "$?" -ne "2" ]; then make push-image; fi'
                 }
             }
 


### PR DESCRIPTION
For our new-fangled kubernetes deployments, we might just want to use some random docker container from dockerhub instead of writing our own Dockerfile. This PR allows us to not include a Makefile that does literally nothing just so Jenkins is happy.