### PR TITLE
Add a generic irc message function, use it for builds pending approval

### DIFF
--- a/vars/checkGitHubAccess.groovy
+++ b/vars/checkGitHubAccess.groovy
@@ -32,9 +32,15 @@ def call(String org='ocf', String credentialsId='ocfbot') {
     if (!env.CHANGE_AUTHOR) {
         println "This doesn't look like a GitHub PR, continuing"
     } else if (!isOrgMember(env.CHANGE_AUTHOR, org, credentialsId)) {
-        ircMessage("Project ${JOB_NAME} (#${BUILD_NUMBER}): \u000309\u0002*Pending approval*\u000f: ${BUILD_URL}")
+        ircMessage(
+            "Project ${JOB_NAME} (#${BUILD_NUMBER}): " +
+            "\u000309\u0002*Pending approval*\u000f, please add " +
+            "${env.CHANGE_AUTHOR} to the GitHub org if they are staff or " +
+            "check if the PR is malicious before approving: ${BUILD_URL}"
+        )
         input(
-            message: "Trusted approval needed for change from ${env.CHANGE_AUTHOR}",
+            message: "${env.CHANGE_AUTHOR} is not in the GitHub org, check " +
+                     "the PR contents and log in to approve the build",
             submitter: 'authenticated'
         )
     } else {

--- a/vars/checkGitHubAccess.groovy
+++ b/vars/checkGitHubAccess.groovy
@@ -32,6 +32,7 @@ def call(String org='ocf', String credentialsId='ocfbot') {
     if (!env.CHANGE_AUTHOR) {
         println "This doesn't look like a GitHub PR, continuing"
     } else if (!isOrgMember(env.CHANGE_AUTHOR, org, credentialsId)) {
+        ircMessage("Project ${JOB_NAME} (#${BUILD_NUMBER}): \u000309\u0002*Pending approval*\u000f: ${BUILD_URL}")
         input(
             message: "Trusted approval needed for change from ${env.CHANGE_AUTHOR}",
             submitter: 'authenticated'

--- a/vars/ircMessage.groovy
+++ b/vars/ircMessage.groovy
@@ -1,0 +1,23 @@
+/** Send a generic message to IRC
+*/
+
+def call(String message,
+         String nick = null,
+         String channel = '#rebuild-spam',
+         String server = 'irc.ocf.berkeley.edu:6697') {
+    if (nick == null) {
+        cleanJobName = JOB_NAME.replaceAll('[^a-zA-Z0-9_-]', '-')
+        nick = "jenkins-${cleanJobName}".take(32)
+    }
+
+    sh """
+        (
+        echo NICK ${nick}
+        echo USER ${nick} 8 * : ${nick}
+        sleep 5
+        echo "JOIN ${channel}"
+        echo "PRIVMSG ${channel} :${message}"
+        echo QUIT
+        ) | chronic openssl s_client -connect ${server}
+    """
+}

--- a/vars/ircNotification.groovy
+++ b/vars/ircNotification.groovy
@@ -13,7 +13,7 @@ def call(String channel = '#rebuild-spam',
 
     if (result == 'SUCCESS') {
         // Display success messages in green text on IRC
-        resultDisplay = "\u000303${result}\u000f"
+        resultDisplay = "\u000303Success\u000f"
     } else {
         // Display failure messages in red bold text on IRC and bold text on Slack
         resultDisplay = "\u000304\u0002*${result}*\u000f"

--- a/vars/ircNotification.groovy
+++ b/vars/ircNotification.groovy
@@ -20,14 +20,5 @@ def call(String channel = '#rebuild-spam',
     }
 
     message = "Project ${JOB_NAME} (#${BUILD_NUMBER}): ${resultDisplay}: ${BUILD_URL}"
-    sh """
-        (
-        echo NICK ${nick}
-        echo USER ${nick} 8 * : ${nick}
-        sleep 5
-        echo "JOIN ${channel}"
-        echo "PRIVMSG ${channel} :${message}"
-        echo QUIT
-        ) | chronic openssl s_client -connect ${server}
-    """
+    ircMessage(message, nick, channel, server)
 }


### PR DESCRIPTION
I split up `ircNotification` into `ircNotification` (unfortunately hard to change the name since it's [used across multiple repos](https://sourcegraph.ocf.berkeley.edu/search?q=ircNotification)) and a new `ircMessage` to send arbitrary messages to IRC.

I then used this new function to send a message if a build is pending approval, since otherwise they just show up as aborted after an hour has passed and nobody has approved them already, which is not a nice developer experience (we could also raise this limit to a longer time period, but this 1 hour is also to catch any runaway or stuck builds). Anyway, the intention of this message is that someone will see the message on IRC, go look at the PR, and approve/deny the build if the PR is not trying to RCE us or something. I'm definitely open to suggestions on how to convey that message clearly if you think this rewording doesn't make it clear.

Finally, I made `SUCCESS` into `Success` since it really doesn't need to be in all caps and makes it even clearer between success/failure. Also, there's enough yelling in the world :P

(tested in #rebuild-spam if you want to take a look there)