### PR TITLE
Add createGist for creating GitHub gists

### DIFF
--- a/vars/createGist.groovy
+++ b/vars/createGist.groovy
@@ -1,0 +1,37 @@
+/** Create a GitHub gist via the Java github-api interface
+ *  See https://github-api.kohsuke.org/apidocs/org/kohsuke/github/GHGist.html
+ *  and
+ *  https://github-api.kohsuke.org/apidocs/org/kohsuke/github/GHGistBuilder.html
+ *  for which methods are available
+ *
+ *  Currently this only supports adding single-file gists, but it could have
+ *  multi-file support added in the future if that is useful.
+*/
+
+import org.kohsuke.github.GHGist
+import org.kohsuke.github.GHGistBuilder
+import org.kohsuke.github.GitHub
+import org.kohsuke.github.GitHubBuilder
+
+def String call(String filename, String content, String credentialsId='ocfbot') {
+    node {
+        withCredentials([usernamePassword(
+            credentialsId: credentialsId,
+            passwordVariable: 'GITHUB_PASSWORD',
+            usernameVariable: 'GITHUB_USERNAME')
+        ]) {
+            final GitHub gh = new GitHubBuilder()
+                .withPassword(env.GITHUB_USERNAME, env.GITHUB_PASSWORD)
+                .build()
+
+            // Start building a gist
+            GHGistBuilder gistBuilder = gh.createGist()
+            // Add a file to the gist with the given filename and content
+            gistBuilder = gistBuilder.file(filename, content)
+            // Actually go and create the gist
+            GHGist gist = gistBuilder.create()
+            // Get a URL with which to refer to the new gist
+            return gist.getHtmlUrl().toString()
+        }
+    }
+}

--- a/vars/createGist.groovy
+++ b/vars/createGist.groovy
@@ -13,7 +13,12 @@ import org.kohsuke.github.GHGistBuilder
 import org.kohsuke.github.GitHub
 import org.kohsuke.github.GitHubBuilder
 
-def String call(String filename, String content, String credentialsId='ocfbot') {
+def String call(
+    String filename,
+    String content,
+    String description='',
+    String credentialsId='ocfbot'
+) {
     node {
         withCredentials([usernamePassword(
             credentialsId: credentialsId,
@@ -28,6 +33,8 @@ def String call(String filename, String content, String credentialsId='ocfbot') 
             GHGistBuilder gistBuilder = gh.createGist()
             // Add a file to the gist with the given filename and content
             gistBuilder = gistBuilder.file(filename, content)
+            // Add the description (if provided)
+            gistBuilder = gistBuilder.description(description)
             // Actually go and create the gist
             GHGist gist = gistBuilder.create()
             // Get a URL with which to refer to the new gist


### PR DESCRIPTION
I've tested this in https://github.com/ocf/puppet/pull/762, where it's used to make a gist if the contents are too big to fit in a pull request comment (max of 65536 characters). Currently, that puppet branch just has this repo pinned to this branch in the `Jenkinsfile`, but I'll unpin it after merging this.

This is also quite similar (and mostly taken from) the code in [`vars/checkGitHubAccess.groovy`](https://github.com/ocf/shared-pipeline/blob/master/vars/checkGitHubAccess.groovy) since that also talks to GitHub in a similar way.

I also had to log in to the ocfbot account and update the access token it's using to talk to GitHub to allow for interacting with gists, since that wasn't a permission originally included.